### PR TITLE
feat: compile server to single Bun binary

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.8 AS base
+FROM oven/bun:1.3.8 AS builder
 WORKDIR /app
 
 COPY bun.lock package.json turbo.json tsconfig.json ./
@@ -7,21 +7,15 @@ COPY packages ./packages
 COPY turbo ./turbo
 
 RUN bun install --frozen-lockfile --linker=hoisted
+RUN cd apps/server && bun build --compile --minify --bytecode --target=bun-linux-x64 ./src/serve.ts --outfile server
 
-FROM base AS builder
-COPY . .
-RUN bun run build --filter server
-
-FROM oven/bun:1.3.8 AS runner
+FROM debian:bookworm-slim AS runner
 WORKDIR /app
-ENV NODE_ENV=production
 
-COPY --from=builder /app/apps/server/dist ./apps/server/dist
-COPY --from=builder /app/apps/server/package.json ./apps/server/package.json
-COPY --from=builder /app/packages/db ./packages/db
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/bun.lock ./bun.lock
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/apps/server/server ./server
+COPY --from=builder /app/packages/db/src/migrations ./migrations
 
 EXPOSE 3000
-CMD ["bun", "run", "--cwd", "apps/server", "start"]
+CMD ["./server"]

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -14,15 +14,16 @@
     "@orpc/openapi": "catalog:",
     "@orpc/server": "catalog:",
     "@orpc/zod": "catalog:",
+    "@solana-stack-attack/analytics": "workspace:*",
     "@solana-stack-attack/api": "workspace:*",
     "@solana-stack-attack/auth": "workspace:*",
     "@solana-stack-attack/db": "workspace:*",
     "@solana-stack-attack/env": "workspace:*",
     "better-auth": "catalog:",
     "dotenv": "catalog:",
+    "drizzle-orm": "^0.45.1",
     "hono": "catalog:",
-    "zod": "catalog:",
-    "@solana-stack-attack/analytics": "workspace:*"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@solana-stack-attack/config": "workspace:*",

--- a/apps/server/src/serve.ts
+++ b/apps/server/src/serve.ts
@@ -1,0 +1,24 @@
+import { db } from '@solana-stack-attack/db'
+import { migrate } from 'drizzle-orm/libsql/migrator'
+
+import app from './index'
+
+const port = Number(process.env.PORT ?? 3000)
+
+async function main() {
+  console.log('Running migrations...')
+  await migrate(db, { migrationsFolder: './migrations' })
+  console.log('Migrations complete.')
+
+  Bun.serve({
+    fetch: app.fetch,
+    port,
+  })
+
+  console.log(`Server running at http://localhost:${port}`)
+}
+
+main().catch((error) => {
+  console.error('Failed to start server:', error)
+  process.exit(1)
+})

--- a/bun.lock
+++ b/bun.lock
@@ -97,6 +97,7 @@
         "@solana-stack-attack/env": "workspace:*",
         "better-auth": "catalog:",
         "dotenv": "catalog:",
+        "drizzle-orm": "^0.45.1",
         "hono": "catalog:",
         "zod": "catalog:",
       },


### PR DESCRIPTION
Replaces the node_modules-heavy server Docker image with a single compiled binary using `bun build --compile`.

**Changes:**
- New `serve.ts` entrypoint with explicit `Bun.serve()` + programmatic DB migrations
- Dockerfile now compiles to a single binary, runner is `debian:bookworm-slim` (no bun/node runtime needed)
- Migration SQL files copied alongside the binary

**Results:**
- **Image size: 1.8GB → 289MB** (74.8MB compressed)
- No more slow `node_modules` copy in the runner stage
- Faster deploys, smaller footprint

**Not included:** Web app still uses the current approach (TanStack Start SSR + dynamic imports don't play well with `bun build --compile` yet).