### PR TITLE
fix: burn transaction signing on web

### DIFF
--- a/apps/web/src/features/burn/data-access/use-burn-upgrades.ts
+++ b/apps/web/src/features/burn/data-access/use-burn-upgrades.ts
@@ -1,4 +1,8 @@
-import { getBase64Encoder } from '@solana/kit'
+import {
+  getBase64Encoder,
+  getTransactionDecoder,
+  getTransactionEncoder,
+} from '@solana/kit'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   type UiWalletAccount,
@@ -49,8 +53,11 @@ export function useSignAndSendBase64Tx() {
 
   return useCallback(
     async (base64Tx: string) => {
-      const txBytes = new Uint8Array(getBase64Encoder().encode(base64Tx))
-      await signAndSend({ transaction: txBytes })
+      // Decode and re-encode to ensure proper wire format with signature slots
+      const txBytes = getBase64Encoder().encode(base64Tx)
+      const decoded = getTransactionDecoder().decode(txBytes)
+      const reEncoded = getTransactionEncoder().encode(decoded)
+      await signAndSend({ transaction: new Uint8Array(reEncoded) })
     },
     [signAndSend],
   )


### PR DESCRIPTION
**Error:** `Can not add signature; wallet is not required to sign this transaction`

**Root cause:** The raw base64 bytes from the server weren't properly preserving signature slot metadata. The wallet (Backpack) couldn't find the user's address as a required signer.

**Fix:** Decode the transaction with `getTransactionDecoder()` then re-encode with `getTransactionEncoder()` before passing to the wallet. This roundtrip ensures the wire format has proper signature slots — matching how the native app handles it.