### PR TITLE
fix: log base64 transaction for burn debugging

### DIFF
--- a/apps/web/src/features/burn/data-access/use-burn-upgrades.ts
+++ b/apps/web/src/features/burn/data-access/use-burn-upgrades.ts
@@ -49,6 +49,7 @@ export function useSignAndSendBase64Tx() {
 
   return useCallback(
     async (base64Tx: string) => {
+      console.log('[Burn] Base64 transaction:', base64Tx)
       const txBytes = new Uint8Array(getBase64Encoder().encode(base64Tx))
       await signAndSend({ transaction: txBytes })
     },


### PR DESCRIPTION
Logs the base64-encoded transaction to console before signing, so it can be inspected in Solana Explorer for debugging burn failures.