### PR TITLE
feat: wallet mismatch guard

### DIFF
--- a/apps/web/src/components/wallet-mismatch-guard.tsx
+++ b/apps/web/src/components/wallet-mismatch-guard.tsx
@@ -1,0 +1,70 @@
+import { useQuery } from '@tanstack/react-query'
+import { ellipsify, useWalletUi } from '@wallet-ui/react'
+import { LucideShieldAlert } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+import { authClient } from '@/lib/auth-client'
+import { orpc } from '@/utils/orpc'
+
+export function WalletMismatchGuard({ children }: { children: ReactNode }) {
+  const { account } = useWalletUi()
+  const { data: session } = authClient.useSession()
+  const { data: wallets } = useQuery({
+    ...orpc.user.wallets.queryOptions(),
+    enabled: !!session?.user,
+  })
+
+  const connectedAddress = account?.address
+
+  // No wallet connected or no session or wallets not loaded yet — let through
+  if (!connectedAddress || !session?.user || !wallets) {
+    return <>{children}</>
+  }
+
+  // Check if connected wallet matches any of the user's linked wallets
+  const isLinked = wallets.some((w) => w.address === connectedAddress)
+
+  if (isLinked) {
+    return <>{children}</>
+  }
+
+  return (
+    <div className="flex h-svh items-center justify-center bg-background p-4">
+      <div className="mx-auto max-w-md space-y-6 text-center">
+        <div className="flex justify-center">
+          <div className="rounded-full bg-destructive/10 p-4">
+            <LucideShieldAlert className="size-12 text-destructive" />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <h1 className="font-bold text-2xl">Wallet Mismatch</h1>
+          <p className="text-muted-foreground">
+            The connected wallet doesn't match your account.
+          </p>
+        </div>
+        <div className="space-y-1 rounded-lg bg-muted p-4 text-left font-mono text-sm">
+          <p>
+            <span className="text-muted-foreground">Connected: </span>
+            {ellipsify(connectedAddress, 8)}
+          </p>
+          <p>
+            <span className="text-muted-foreground">Expected: </span>
+            {wallets.map((w) => ellipsify(w.address, 8)).join(', ')}
+          </p>
+        </div>
+        <p className="text-muted-foreground text-sm">
+          Switch to the correct wallet or sign out and reconnect.
+        </p>
+        <div className="flex flex-col gap-3">
+          <Button
+            variant="destructive"
+            className="w-full"
+            onClick={() => authClient.signOut()}
+          >
+            Sign Out
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -11,6 +11,7 @@ import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { Toaster } from '@/components/ui/sonner'
 import type { orpc } from '@/utils/orpc'
 import { BottomTabs } from '../components/header'
+import { WalletMismatchGuard } from '../components/wallet-mismatch-guard'
 import { GameProvider } from '../features/game/data-access/game-provider'
 
 import appCss from '../index.css?url'
@@ -64,12 +65,14 @@ function RootDocument() {
       </head>
       <body>
         <GameProvider>
-          <div
-            className={`h-svh overflow-y-auto ${isAuthenticated ? 'pb-16' : ''}`}
-          >
-            <Outlet />
-          </div>
-          {isAuthenticated && <BottomTabs />}
+          <WalletMismatchGuard>
+            <div
+              className={`h-svh overflow-y-auto ${isAuthenticated ? 'pb-16' : ''}`}
+            >
+              <Outlet />
+            </div>
+            {isAuthenticated && <BottomTabs />}
+          </WalletMismatchGuard>
         </GameProvider>
         <Toaster richColors />
         <TanStackRouterDevtools position="top-left" />

--- a/packages/api/src/features/user/index.ts
+++ b/packages/api/src/features/user/index.ts
@@ -1,0 +1,1 @@
+export { userRouter } from './router'

--- a/packages/api/src/features/user/router.ts
+++ b/packages/api/src/features/user/router.ts
@@ -1,0 +1,23 @@
+import { db } from '@solana-stack-attack/db'
+import { walletAddress } from '@solana-stack-attack/db/schema/auth'
+import { eq } from 'drizzle-orm'
+
+import { protectedProcedure } from '../../index'
+
+export const userRouter = {
+  /** Get the current user's linked wallet addresses */
+  wallets: protectedProcedure.handler(async ({ context }) => {
+    const userId = context.session.user.id
+
+    const wallets = await db
+      .select({
+        address: walletAddress.address,
+        cluster: walletAddress.cluster,
+        isPrimary: walletAddress.isPrimary,
+      })
+      .from(walletAddress)
+      .where(eq(walletAddress.userId, userId))
+
+    return wallets
+  }),
+}

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -2,6 +2,7 @@ import type { RouterClient } from '@orpc/server'
 import { burnRouter } from '../features/burn'
 import { gameRouter } from '../features/game'
 import { rewardRouter } from '../features/reward'
+import { userRouter } from '../features/user'
 import { publicProcedure } from '../index'
 import { feePayerRouter } from './fee-payer'
 
@@ -13,6 +14,7 @@ export const appRouter = {
   feePayer: feePayerRouter,
   game: gameRouter,
   reward: rewardRouter,
+  user: userRouter,
 }
 export type AppRouter = typeof appRouter
 export type AppRouterClient = RouterClient<typeof appRouter>


### PR DESCRIPTION
Blocks the app when the connected wallet doesn't match any wallet linked to the user's account.

**What it does:**
- Adds `user.wallets` API endpoint to fetch the current user's linked wallet addresses
- Adds `WalletMismatchGuard` component that compares connected wallet vs linked wallets
- If mismatch: shows a full-screen overlay with both addresses and a sign out button
- If match or no wallet connected: renders children normally

**Why:**
The burn flow builds transactions server-side using the wallet address from the DB. If the browser wallet doesn't match, the tx will have a noop signer for the wrong address and the wallet extension will error with 'Can not add signature; X is not required to sign this transaction'.

Supports multiple wallets (future-ready) — checks against all linked addresses.