### PR TITLE
feat: polyfill signIn for wallets without solana:signIn support

### DIFF
--- a/apps/web/src/components/solana/use-handle-siws-auth-mutation.ts
+++ b/apps/web/src/components/solana/use-handle-siws-auth-mutation.ts
@@ -2,9 +2,9 @@ import { assertIsAddress } from '@solana/kit'
 import { env } from '@solana-stack-attack/env/web'
 import { useMutation } from '@tanstack/react-query'
 import type { UiWallet, UiWalletAccount } from '@wallet-ui/react'
-import { useSignIn } from '@wallet-ui/react'
 import { authClient } from '@/lib/auth-client'
 import { handleSiwsAuth } from './handle-siws-auth'
+import { useSignInCompat } from './use-sign-in-compat'
 
 interface UseSiwsAuthOptions {
   account: UiWalletAccount
@@ -29,7 +29,7 @@ export function useHandleSiwsAuthMutation({
   const address = account.address
   assertIsAddress(address)
   const session = authClient.useSession()
-  const signIn = useSignIn(wallet)
+  const signIn = useSignInCompat(wallet, account)
 
   return useMutation({
     mutationFn: () =>

--- a/apps/web/src/components/solana/use-sign-in-compat.ts
+++ b/apps/web/src/components/solana/use-sign-in-compat.ts
@@ -1,0 +1,107 @@
+import type {
+  SolanaSignInInput,
+  UiWallet,
+  UiWalletAccount,
+} from '@wallet-ui/react'
+import { useSignIn, useSignMessage } from '@wallet-ui/react'
+import { useCallback } from 'react'
+
+/** Minimal shape that both signIn and our signMessage fallback return */
+interface SignInResult {
+  account: { address: string }
+  signedMessage: Uint8Array
+  signature: Uint8Array
+}
+
+/**
+ * Build a Sign In With Solana (SIWS) message string from the input fields.
+ * Follows the SIWS spec: https://github.com/phantom/sign-in-with-solana
+ */
+function buildSiwsMessage(input: SolanaSignInInput): string {
+  const lines: string[] = []
+
+  if (input.domain) {
+    lines.push(`${input.domain} wants you to sign in with your Solana account:`)
+  }
+  if (input.address) {
+    lines.push(input.address)
+  }
+  if (input.statement) {
+    lines.push('')
+    lines.push(input.statement)
+  }
+
+  lines.push('')
+
+  if (input.uri) {
+    lines.push(`URI: ${input.uri}`)
+  }
+  if (input.version) {
+    lines.push(`Version: ${input.version}`)
+  }
+  if (input.chainId) {
+    lines.push(`Chain ID: ${input.chainId}`)
+  }
+  if (input.nonce) {
+    lines.push(`Nonce: ${input.nonce}`)
+  }
+  if (input.issuedAt) {
+    lines.push(`Issued At: ${input.issuedAt}`)
+  }
+  if (input.expirationTime) {
+    lines.push(`Expiration Time: ${input.expirationTime}`)
+  }
+  if (input.requestId) {
+    lines.push(`Request ID: ${input.requestId}`)
+  }
+  if (input.resources && input.resources.length > 0) {
+    lines.push('Resources:')
+    for (const resource of input.resources) {
+      lines.push(`- ${resource}`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * A compatible version of useSignIn that falls back to signMessage
+ * for wallets that don't support the solana:signIn feature (e.g. Jupiter).
+ */
+export function useSignInCompat(
+  wallet: UiWallet,
+  account: UiWalletAccount,
+): (input: SolanaSignInInput) => Promise<SignInResult> {
+  const supportsSignIn = wallet.features.includes('solana:signIn')
+  // Always call both hooks unconditionally (React rules of hooks)
+  const signIn = useSignIn(wallet)
+  const signMessage = useSignMessage(account)
+
+  return useCallback(
+    async (input: SolanaSignInInput): Promise<SignInResult> => {
+      if (supportsSignIn) {
+        const result = await signIn(input)
+        return {
+          account: result.account,
+          signedMessage: result.signedMessage,
+          signature: result.signature,
+        }
+      }
+
+      // Fallback: construct SIWS message and use signMessage
+      console.log(
+        '[Auth] Wallet does not support solana:signIn, falling back to signMessage',
+      )
+      const messageText = buildSiwsMessage(input)
+      const messageBytes = new TextEncoder().encode(messageText)
+      const { signature } = await signMessage({ message: messageBytes })
+
+      return {
+        account: { address: account.address },
+        signedMessage: messageBytes,
+        signature,
+      }
+    },
+    [supportsSignIn, signIn, signMessage, account],
+  )
+}


### PR DESCRIPTION
Fixes Wallet Standard error #6160002 when using wallets like Jupiter that don't support `solana:signIn`.

**Problem:**
Jupiter wallet (and others) only supports `signMessage`, `signTransaction`, `signAndSendTransaction` — not the `solana:signIn` (SIWS) feature. Our auth flow requires `signIn`, causing an immediate crash.

**Solution:**
- New `useSignInCompat` hook that detects wallet capabilities at runtime
- If wallet supports `solana:signIn` → uses native flow (no change)
- If not → constructs the SIWS message text manually and uses `signMessage` as fallback
- The server-side verify endpoint receives the same message + signature either way

**Changes:**
- `use-sign-in-compat.ts` — new compat hook with SIWS message builder
- `use-handle-siws-auth-mutation.ts` — swapped `useSignIn` for `useSignInCompat`
- `handle-siws-auth.ts` — loosened types to accept both signIn and signMessage output shapes